### PR TITLE
Remove Trusted check from Github source

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1003,7 +1003,11 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                 }
             }
             PullRequestSCMHead head = (PullRequestSCMHead) revision.getHead();
-            if (!collaboratorNames.contains(head.getSourceOwner())) {
+            /**
+             * removed because it looks like this check is broken and so is not using Jenkinsfile changes
+             * if (!collaboratorNames.contains(head.getSourceOwner())) {
+            */
+            if (false) {
                 PullRequestSCMRevision rev = (PullRequestSCMRevision) revision;
                 listener.getLogger().format("Loading trusted files from base branch %s at %s rather than %s%n",
                         head.getTarget().getName(), rev.getBaseHash(), rev.getPullHash());


### PR DESCRIPTION
Do not merge **This is the plugin version we are using** 

Because of the isTrusted check Jenkins is using the Jenkinsfile version from the basebranch
instead of the one from the Branch actually tested. The User who created the branch is trusted
but Jenkins is not recognizing that correctly.